### PR TITLE
Add missing switch for REST API port specification

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -116,6 +116,7 @@ log 'info'  "Starting otbr-agent..."
 exec s6-notifyoncheck -d -s 300 -w 300 -n 0 stdbuf -oL \
     "/usr/sbin/otbr-agent" -I ${thread_if} -B "${backbone_if}" \
         --rest-listen-address "${otbr_rest_listen}" \
+        --rest-listen-port "${otbr_rest_listen_port}" \
         -d${otbr_log_level_int} -v -s \
         "spinel+hdlc+uart://${device}?uart-baudrate=${baudrate}${flow_control}" \
         "trel://${backbone_if}"


### PR DESCRIPTION
This pull request includes an update to the `otbr-agent` configuration to allow specifying a custom REST listen port.

Configuration update:

* [`rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run`](diffhunk://#diff-f41634d8ed2d3992c63ba64e818c8faa89864ebfb4cdec502da5e7e0cd8da6aeR119): Added the `--rest-listen-port` parameter to the `otbr-agent` command to allow specifying a custom REST listen port.The variable `OTBR_REST_PORT` was ignored in the docker image. Now it's using the port specified in docker compose file.
