### PR TITLE
Reduce logging output in default docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ read documentation and forum threads and eventually got it working using this se
     | BAUDRATE           | Serial port baudrate (depends on firmware)   |
     | FLOW_CONTROL (1 or 0) | If hardware flow control should be enabled (depends on firmware) |
     | AUTOFLASH_FIRMWARE (1 or 0) | Automatically install/update firmware (Home Assistant SkyConnect/Yellow) |
-    | OTBR_LOG_LEVEL     | Set the log level of the OpenThread BorderRouter Agent (info)    |
+    | OTBR_LOG_LEVEL     | Set the log level of the OpenThread BorderRouter Agent (debug,info,notice,warning,error,critical,alert,emergency)    |
     | OTBR_REST_PORT     | Port for REST API used by home assistant |
     | OTBR_WEB_PORT      | Port for WEB UI |
     | OTBR_WEB (1 or 0)  | Enable or disable WEB UI |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,17 @@ services:
       OTBR_REST_PORT: 8081
       OTBR_WEB_PORT: 7586
       AUTOFLASH_FIRMWARE: 0
+      OTBR_LOG_LEVEL: error
     devices:
       - /dev/ttyUSB1:/dev/ttyUSB1
       - /dev/net/tun:/dev/net/tun
     volumes:
       - ./otbr_data:/data/thread
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "3"
+        max-size: "1m"
 
   # Matter server example (the standard image)
   matter-server:
@@ -37,6 +43,11 @@ services:
       - ./matter_data:/data/
       - /run/dbus:/run/dbus:ro  # For bluetooth
       - /etc/localtime:/etc/localtime:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "3"
+        max-size: "1m"
     command: >
       --storage-path /data
       --paa-root-cert-dir /data/credentials


### PR DESCRIPTION
I faced the problem, that with the default docker-compose.yaml my SSD filled up really quick.

Solution:
Provide some defaults for log rotation and lower log level.

This does not entirely fix the leaking of disk space, but brings it down to a manageable level.